### PR TITLE
Fix ootp

### DIFF
--- a/simulator/components/device/otaa.go
+++ b/simulator/components/device/otaa.go
@@ -111,9 +111,12 @@ func (d *Device) ProcessJoinAccept(JoinAccPayload *lorawan.JoinAcceptPayload) (*
 	var err error
 
 	//setkeys
-	d.Info.NwkSKey, err = act.GetKey(d.Info.NetID, JoinAccPayload.JoinNonce, d.Info.DevNonce, d.Info.AppKey, act.PadNwkSKey)
-	d.Info.AppSKey, err = act.GetKey(d.Info.NetID, JoinAccPayload.JoinNonce, d.Info.DevNonce, d.Info.AppKey, act.PadAppSKey)
+	d.Info.NwkSKey, err = act.GetKey(JoinAccPayload.HomeNetID, JoinAccPayload.JoinNonce, d.Info.DevNonce, d.Info.AppKey, act.PadNwkSKey)
+	if err != nil {
+		return nil, err
+	}
 
+	d.Info.AppSKey, err = act.GetKey(JoinAccPayload.HomeNetID, JoinAccPayload.JoinNonce, d.Info.DevNonce, d.Info.AppKey, act.PadAppSKey)
 	if err != nil {
 		return nil, err
 	}

--- a/simulator/components/forwarder/forwarder.go
+++ b/simulator/components/forwarder/forwarder.go
@@ -20,11 +20,14 @@ type Forwarder struct {
 	Mutex    sync.Mutex
 }
 
+// GPS offset compensates for the drift between UTC and GPS time
+const GPSOffset = 18000
+
 func createPacket(info pkt.RXPK) pkt.RXPK {
 
 	tnow := time.Now()
 	offset, _ := time.Parse(time.RFC3339, "1980-01-06T00:00:00Z")
-	tmms := tnow.Unix() - offset.Unix()
+	tmms := tnow.UnixMilli() - offset.UnixMilli() + GPSOffset
 
 	rxpk := pkt.RXPK{
 


### PR DESCRIPTION
These changes are needed to allow simulated devices to properly perform OOTP.
Changes were tested against a local instance of TheThingsStack.

