### PR TITLE
Add build from docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.20-alpine3.17 as build
+
+RUN apk update
+RUN apk add make
+
+ADD . /build/src
+WORKDIR /build/src
+#RUN make install-dep
+RUN go install github.com/rakyll/statik@latest
+RUN make build
+
+# deployment image
+FROM alpine:3.17.2
+WORKDIR /app
+
+COPY --from=build /build/src/bin/config.json /app/config.json
+COPY --from=build /build/src/bin/lwnsimulator /app/lwnsimulator
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/lwnsimulator"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ make run
 make run-release
 ```
 
+### From docker
+
+First, build the docker image:
+```bash
+docker-compose build
+```
+
+Then, run the built container:
+```bash
+docker-compose up
+```
+
 ### Configuration file
 The simulator relises on a configuration file (`config.json`) whitch specifies some configurations for the simulator:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  lorawan-simulator:
+    container_name: lorawan-simulator
+    hostname: lorawan-simulator
+    image: lorawan-simulator
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8000:8000
+    volumes:
+      - './data:/root/lwnsimulator'


### PR DESCRIPTION
adds a simple docker-compose file and Dockerfile to build the simulator from source and spin up the service as a container