### PR TITLE
Fix missing hyphen in README cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ git clone https://github.com/UniCT-ARSLab/LWN-Simulator.git
 After the download, you must enter in main directory:
 
 ```bash
-cd LWNSimulator
+cd LWN-Simulator
 ```
 You must install all dependencies to build the simulator:
 ```bash


### PR DESCRIPTION
I'm assuming the repo name has changed and only the clone command was updated.